### PR TITLE
サインイン機能の実装

### DIFF
--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -18,7 +18,7 @@
       .right_lists
         - if user_signed_in?
           .user_btn
-            = link_to "ログアウト", '/users/sign_out', class: 'login_btn'
+            = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'login_btn'
         - else
           .user_btn
             = link_to "新規会員登録", '/users/sign_up', class: 'sign_up_btn'


### PR DESCRIPTION
# WHAT
サインイン機能
# WHY
ユーザー管理の際にサインアップ済みのアカウントを使用するときにサインアップしてcurrent_userとして扱えるようにするため。
## 補足
フロントを作る際にフォームなどの形を実際の形にしていて、deviseを使用しているため変更したコードはありません。
ヘッダーのログアウトのパスの修正だけしてあります。
ログインできていてcurrent_userとして扱えているか確認するためGYAZO内ではヘッダーにcurrent_user.nicknameを表示しています。(本当には使用しないためコミットはしていません)
## GYAZO
https://gyazo.com/1c9f247a6c050929cb3abe13fdfc22d1
https://gyazo.com/0d3e7147759496f757707a7ab47a067f
https://gyazo.com/faf9b160d0e3bb90edbbffe95d885f7e
https://gyazo.com/ee45213150876aed966c4e6e3c66935f