### PR TITLE
出品ページでの値段へのバリデーションの追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,10 @@
 class ItemsController < ApplicationController
   
   before_action :set_item, only: [:edit, :update]
-  before_action :move_to_index, only: :edit
+  before_action :move_to_index, only: [:edit]
+  before_action :move_to_index_second, only: [:new, :create]
+
+
   
   def get_category_children
     @category_children = Category.find(params[:parent_id]).children
@@ -111,7 +114,11 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to root_path unless @item.user_id == current_user.id
+    redirect_to root_path unless user_signed_in? && @item.user_id == current_user.id
+  end
+
+  def move_to_index_second
+    redirect_to root_path unless user_signed_in?
   end
 end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,7 +18,7 @@ class Item < ApplicationRecord
   
   with_options presence: true do
     validates :name
-    validates :price
+    validates :price,numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
     validates :status
     validates :delivery_method
     validates :delivery_from_location

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -108,7 +108,7 @@
         .form__price
           .form__price__head
             %h5.form__title
-              販売価格
+              販売価格 (300〜9,999,999円)
             %span.required__text
               必須
           .form__price__box


### PR DESCRIPTION
# WHAT
300~9,999,999でないと値段を登録できないようにバリデーションを記述した
# WHY
最小の値段はメルカリに倣って、最大は9.999,999円まで出ないとPAY.JPでの決済が不可能になるため