### PR TITLE
Update user-show-page

### DIFF
--- a/app/assets/stylesheets/modules/_user-show.scss
+++ b/app/assets/stylesheets/modules/_user-show.scss
@@ -144,6 +144,12 @@
       }
     }
   }
+  h2.no-items-msg {
+    height: 300px;
+    font-size: 20px;
+    text-align: center;
+    line-height: 300px;
+  }
 }
 
 .sell-btn {

--- a/app/views/users/_item.html.haml
+++ b/app/views/users/_item.html.haml
@@ -2,7 +2,7 @@
   .items-box
     = link_to item_path(item.id) do
       .items-box__photo
-        = image_tag item.item_images[0].image.url
+        = image_tag item.item_images[0].image.url, height: '220px', width: '220px'
       .items-box__body
         %h3.items-name
           = item.name

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,7 @@
 .users-details
   .users-detail-profile-box
     .users-detail-photo-box
-      = link_to "#" do
+      = link_to user_path(@user.id) do
         .users-detail-photo
           = image_tag('member_photo_noimage_thumb.png', height: '180px', width: '180px')
         %h2
@@ -47,6 +47,6 @@
     - else
       %h2.no-items-msg 出品した商品はありません
 
-  = link_to "#", class: "sell-btn" do
+  = link_to new_item_path, class: "sell-btn" do
     %div 出品する
     = image_tag "icon_camera.png", size: "54x54", class: "camera-icon"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -30,7 +30,7 @@
         - bad_rates = UserRate.where(user_id: @user.id, rate: "bad").length
         = "#{bad_rates}"
   .users-self-introduce-area
-    = "#{Profile.find_by(user_id: @user.id).introduction}"
+    = "#{Profile.find_by(user_id: @user.id)&.introduction}"
   .social-media-box
     = link_to "#", class: "facebook" do
       = icon('fab', 'facebook-square', class: "facebook-icon")
@@ -41,8 +41,11 @@
   .items-box-container
     %h2.items-box-head
       この出品者の商品
-    .items-box-content
-      = render partial: 'item', collection: @items
+    - if @items.present?
+      .items-box-content
+        = render partial: 'item', collection: @items
+    - else
+      %h2.no-items-msg 出品した商品はありません
 
   = link_to "#", class: "sell-btn" do
     %div 出品する


### PR DESCRIPTION
# What
・プロフィール未登録状態（自己紹介）でもユーザー詳細ページにアクセスできるようにした。
・出品商品がない場合には出品した商品はありませんというメッセージが出るようにした。

# Why
ユーザー詳細ページにアクセスしたときにエラーが出ないようにするため

# Image
↓プロフ登録（自己紹介）済み、出品あり
https://i.gyazo.com/5b1075607775defd9345a34e742684d2.gif

↓プロフ登録（自己紹介）なし、出品なし
https://i.gyazo.com/4f1aa63ed49dd3c99ea1a49f3364b0e1.gif