### PR TITLE
商品出品ページの戻るボタンのリンク先の変更

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -121,4 +121,3 @@ class ItemsController < ApplicationController
     redirect_to root_path unless user_signed_in?
   end
 end
-

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -126,4 +126,4 @@
         .submit-btn
           = form.submit "下書きに保存", class: "draft-btn"
         .item__back
-          = link_to "戻る", :back
+          = link_to "戻る", root_path


### PR DESCRIPTION
# WHAT
商品出品ページの戻るボタンのリンク先をrootパスに固定
# WHY
今まで一つ戻るリンクだったため入力情報が不足してフォームにリダイレクトした際に戻るボタンが出品ページに戻るという仕様だったから。
