### PR TITLE
Add js for mypage

### DIFF
--- a/app/assets/javascripts/mypage.js
+++ b/app/assets/javascripts/mypage.js
@@ -1,0 +1,24 @@
+$(function(){
+  let tabs1 = $(".mypage-tab-notification-todo li h3")
+  let tabs2 = $(".mypage-tab-items li h3")
+
+  function tabSwitch1() {
+    $(".mypage-tab-notification-todo li.active").removeClass("active");
+    $(this).parent().addClass("active");
+
+    const index = tabs1.index(this);
+    $("#mypage-tab.notification-todo").removeClass("active").eq(index).addClass("active");
+  }
+
+  function tabSwitch2() {
+    $(".mypage-tab-items li.active").removeClass("active");
+    $(this).parent().addClass("active");
+
+    const index = tabs2.index(this);
+    $("#mypage-tab.items").removeClass("active").eq(index).addClass("active");
+  }
+
+  tabs1.click(tabSwitch1);
+  tabs2.click(tabSwitch2);
+
+})

--- a/app/assets/stylesheets/modules/_mypage-index.scss
+++ b/app/assets/stylesheets/modules/_mypage-index.scss
@@ -95,7 +95,11 @@ ul.mypage-tabs {
     border-top: 2px solid #ea352d;
   }
 }
-ul.mypage-tab-notification.tab-pane.active {
+ul#mypage-tab {
+  display: none;
+}
+ul#mypage-tab.active {
+  display: block;
   li {
     a {
       display: block;
@@ -140,6 +144,7 @@ ul.mypage-tab-notification.tab-pane.active {
     }
   }
 }
+
 .mypage-side-bar {
   nav.mypage-nav {
     ul.mypage-nav-list {

--- a/app/views/my_pages/_items_list.html.haml
+++ b/app/views/my_pages/_items_list.html.haml
@@ -1,0 +1,62 @@
+%section.mypage-tab-items
+  %h2.mypage-tab-head
+    購入した商品
+  %ul.mypage-tabs
+    %li.active
+      %h3
+        = link_to "取引中", "#"
+    %li
+      %h3
+        = link_to "過去の取引", "#"
+  .tab-content
+    %ul#mypage-tab.items.ongoing.active
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "テストさんからコメントがあります"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "テストさんからコメントがあります"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li.mypage-go-list
+        = link_to "一覧を見る", "#"
+
+    %ul#mypage-tab.items.done
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "取引が完了しました"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "取引が完了しました"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li.mypage-go-list
+        = link_to "一覧を見る", "#"

--- a/app/views/my_pages/_notification_todo_list.html.haml
+++ b/app/views/my_pages/_notification_todo_list.html.haml
@@ -1,0 +1,60 @@
+%section.mypage-tab-notification-todo
+  %ul.mypage-tabs
+    %li.active
+      %h3
+        = link_to "お知らせ", "#"
+    %li
+      %h3
+        = link_to "やることリスト", "#"
+  .tab-content
+    %ul#mypage-tab.notification-todo.notification.active
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "事務局からおしらせがあります"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "事務局からおしらせがあります"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li.mypage-go-list
+        = link_to "一覧を見る", "#"
+    %ul#mypage-tab.notification-todo.todo
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "商品を発送してください"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li
+        = link_to "#" do
+          %figure
+            = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
+          .mypage-item-body
+            .message-item
+              = "商品を発送してください"
+            .message-time-before
+              = icon('far', 'clock', class: "clock-icon")
+              %span 1時間前
+          = icon('fas', 'chevron-right', class: "arrow-icon")
+      %li.mypage-go-list
+        = link_to "一覧を見る", "#"
+          

--- a/app/views/my_pages/index.html.haml
+++ b/app/views/my_pages/index.html.haml
@@ -11,77 +11,9 @@
             = "評価  #{@rates}"
           %span
             = "出品数  #{@items}"
-    %section.mypage-tab-notification-todo
-      %ul.mypage-tabs
-        %li.active
-          %h3
-            = link_to "お知らせ", "#"
-        %li
-          %h3
-            = link_to "やることリスト", "#"
-      .tab-content
-        %ul.mypage-tab-notification.tab-pane.active
-          %li
-            = link_to "#" do
-              %figure
-                = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
-              .mypage-item-body
-                .message-item
-                  = "事務局からおしらせがあります"
-                .message-time-before
-                  = icon('far', 'clock', class: "clock-icon")
-                  %span 1時間前
-              = icon('fas', 'chevron-right', class: "arrow-icon")
-          %li
-            = link_to "#" do
-              %figure
-                = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
-              .mypage-item-body
-                .message-item
-                  = "事務局からおしらせがあります"
-                .message-time-before
-                  = icon('far', 'clock', class: "clock-icon")
-                  %span 1時間前
-              = icon('fas', 'chevron-right', class: "arrow-icon")
-          %li.mypage-go-list
-            = link_to "一覧を見る", "#"
-              
-    %section.mypage-tab-items
-      %h2.mypage-tab-head
-        購入した商品
-      %ul.mypage-tabs
-        %li.active
-          %h3
-            = link_to "取引中", "#"
-        %li
-          %h3
-            = link_to "過去の取引", "#"
-      .tab-content
-        %ul.mypage-tab-notification.tab-pane.active
-          %li
-            = link_to "#" do
-              %figure
-                = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
-              .mypage-item-body
-                .message-item
-                  = "事務局からおしらせがあります"
-                .message-time-before
-                  = icon('far', 'clock', class: "clock-icon")
-                  %span 1時間前
-              = icon('fas', 'chevron-right', class: "arrow-icon")
-          %li
-            = link_to "#" do
-              %figure
-                = image_tag('member_photo_noimage_thumb.png',  height: '30px', width: '30px', class: "list-icon")
-              .mypage-item-body
-                .message-item
-                  = "事務局からおしらせがあります"
-                .message-time-before
-                  = icon('far', 'clock', class: "clock-icon")
-                  %span 1時間前
-              = icon('fas', 'chevron-right', class: "arrow-icon")
-          %li.mypage-go-list
-            = link_to "一覧を見る", "#"
+    = render "notification_todo_list"
+
+    = render "items_list"
   
   = render partial: 'side_bar', locals: {card: @card}
 


### PR DESCRIPTION
# What
・マイページのお知らせ一覧等のタブをjsで切り替えられるようにした。
・部分テンプレートを新しく作成して、ビューファイルを見やすくした。

# Why
リクエストを飛ばさずに表示の切り替えをして、お知らせ等の表示を簡単に見れるようにするため。

# Image
https://i.gyazo.com/a88a291d75ff498fcfa9129c242dfb37.gif