### PR TITLE
Profile image form

### DIFF
--- a/app/assets/javascripts/profile-form.js
+++ b/app/assets/javascripts/profile-form.js
@@ -1,0 +1,18 @@
+$(function(){
+  const buildImg = (url)=> {
+    const html = `<div class="profile-image">
+                  <img width="150px" height="150px" src="${url}" >
+                  </div>`;
+    return html;
+  }
+
+  // $("#profile-image-preview").attr("for",`profile[image]`);
+  
+  $("#profile-image-form").on("change", function(e){
+    console.log("OK")
+    $("img").remove();
+    const blobUrl = window.URL.createObjectURL(e.target.files[0]);
+    $("#profile-image-preview").append(buildImg(blobUrl));
+    $("img").css("border-radius","50%");
+  })
+})

--- a/app/assets/javascripts/profile-form.js
+++ b/app/assets/javascripts/profile-form.js
@@ -5,8 +5,6 @@ $(function(){
                   </div>`;
     return html;
   }
-
-  // $("#profile-image-preview").attr("for",`profile[image]`);
   
   $("#profile-image-form").on("change", function(e){
     console.log("OK")

--- a/app/assets/stylesheets/modules/_mypage-index.scss
+++ b/app/assets/stylesheets/modules/_mypage-index.scss
@@ -55,6 +55,9 @@
     }
     .mypage-user-photo {
       margin: 0 auto;
+      img {
+        border-radius: 50%;
+      }
     }
     span {
       margin-right: 10px;

--- a/app/assets/stylesheets/modules/_profile-form.scss
+++ b/app/assets/stylesheets/modules/_profile-form.scss
@@ -46,6 +46,22 @@
         margin: 0 auto;
         margin-bottom: 24px;
       }
+      #profile-image-preview {
+        height: 150px;
+        width: 150px;
+        margin: 0 auto;
+        border-radius: 50%;
+        text-align: center;
+        margin-top: 20px;
+        img.profile-image {
+          height: 150px;
+          width: 150px;
+          border-radius: 50%;
+        }
+        #profile-image-form {
+          display: none;
+        }
+      }
       ul.icon-list {
         display: flex;
         margin-top: 8px;

--- a/app/assets/stylesheets/modules/_user-show.scss
+++ b/app/assets/stylesheets/modules/_user-show.scss
@@ -11,8 +11,10 @@
     background-size: cover;
     .users-detail-photo-box {
       .users-detail-photo {
-        border-radius: 50%;
         margin: 0 auto;
+        img {
+          border-radius: 50%;
+        }
       }
       a {
         text-decoration: none;

--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -3,6 +3,7 @@ class MyPagesController < ApplicationController
   
   def index
     @user = current_user
+    @profile = Profile.find_by(user_id: @user.id)
     @rates = UserRate.where(user_id: @user.id).length
     @items = Item.where(user_id: @user.id).length
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -34,7 +34,7 @@ class ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.require(:profile).permit(:post_code, :tel_number, :prefecture_id, :city, :address, :building, :image, :introduction).merge(user_id: current_user.id)
+    params.require(:profile).permit(:image, :post_code, :tel_number, :prefecture_id, :city, :address, :building, :image, :introduction).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @profile = Profile.find_by(user_id: @user.id)
     @items = Item.where(user_id: @user.id).includes(:item_images)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -11,4 +11,5 @@ class Profile < ApplicationRecord
     validates :address
   end
 
+  mount_uploader :image, ImageUploader
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -122,7 +122,10 @@
                 = link_to user_path(comment.user_id), class: "user__nickname" do
                   = comment.user.nickname
                 = link_to user_path(comment.user_id) do
-                  = image_tag "member_photo_noimage_thumb.png", class: "user__image"
+                  - if comment.user.profile&.image.blank?
+                    = image_tag "member_photo_noimage_thumb.png", class: "user__image"
+                  - else
+                    = image_tag "#{comment.user.profile.image.url}", class: "user__image"
               .comment__list__content__message
                 = simple_format(comment.content)
                 .comment__list__content__message__icons

--- a/app/views/my_pages/index.html.haml
+++ b/app/views/my_pages/index.html.haml
@@ -3,7 +3,10 @@
     %section.mypage-user-icon
       = link_to my_pages_path do
         .mypage-user-photo
-          = image_tag('member_photo_noimage_thumb.png',  height: '60px', width: '60px')
+          - if @profile&.image.blank?
+            = image_tag('member_photo_noimage_thumb.png', height: '60px', width: '60px')
+          - else
+            = image_tag "#{@profile.image.url}", class: "profile-image", height: '60px', width: '60px'
         %h2.user-name
           = @user.nickname
         .mypage-score

--- a/app/views/profiles/_form.html.haml
+++ b/app/views/profiles/_form.html.haml
@@ -3,6 +3,17 @@
     %h2 プロフィール情報
     = form_with(model: @profile, local: true, class: "profile-form") do |f|
       .form-content
+        = f.label :プロフィール画像
+        %span.form-content__option 任意
+        %label#profile-image
+          #profile-image-preview
+            - if @profile.image.blank?
+              = image_tag('member_photo_noimage_thumb.png', height: '60px', width: '60px', class: "profile-image")
+            - else
+              = image_tag "#{@profile.image.url}", class: "profile-image"
+            = f.file_field :image, id: "profile-image-form"
+
+      .form-content
         = f.label :郵便番号
         %span.form-content__require 必須
         = f.text_field :post_code, placeholder: "例）1500002"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -3,7 +3,10 @@
     .users-detail-photo-box
       = link_to user_path(@user.id) do
         .users-detail-photo
-          = image_tag('member_photo_noimage_thumb.png', height: '180px', width: '180px')
+          - if @profile&.image.blank?
+            = image_tag('member_photo_noimage_thumb.png', height: '180px', width: '180px')
+          - else
+            = image_tag "#{@profile.image.url}", class: "profile-image", height: '180px', width: '180px'
         %h2
           = @user.nickname
     .users-score


### PR DESCRIPTION
# What
プロフィール画像を登録できるようにした。
・プロフ登録フォームの修正
・マイページ、ユーザー詳細ページ、コメント一覧にプロフ画像を表示できるようにした。
・プロフ登録またはプロフ画像登録してない場合はデフォルトイメージが表示される

# Why
各ユーザーをイメージでも認識できるようにするため。

# Image
・画像登録、更新の流れ
https://i.gyazo.com/b29187a964b888d693e391e9e4c14fac.gif
https://i.gyazo.com/d0a7bac50ffc8938749370f7a04eaec8.gif
https://i.gyazo.com/3796938e8206b9b2d44e08766fe295bf.gif
https://i.gyazo.com/c13d365624a0620065cfaa89a8eba043.gif

・ユーザー詳細ページ
https://i.gyazo.com/d295e6c7d73553ce3a5e6b31ae21642d.jpg

・コメント欄
https://i.gyazo.com/2deda22fedcdb776e65afbfe34972bc2.png